### PR TITLE
Update README.md for 'brew' correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Commands:
 [Homebrew](https://brew.sh) is the preferred way to install:
 
 ```sh
-$ brew install zero-sh/tap/zero-sh
+$ brew install zero-sh/tap/zero
 ```
 
 Alternatively, pre-compiled binaries are available on the [releases


### PR DESCRIPTION
Corrected 'brew' installation. Removed errant "-sh" at end: now "brew install zero-sh/tap/zero".