### PR TITLE
feat: add remove not present option in setup and bundle command

### DIFF
--- a/Sources/Zero/Commands/Bundle.swift
+++ b/Sources/Zero/Commands/Bundle.swift
@@ -7,12 +7,16 @@ final class BundleCommand: Command {
     let shortDescription: String = "Run brew bundle on a workspace"
     @Param var workspace: Workspace?
     @Key("-d", "--directory") var configDirectory: Path?
-
+    
+    @Flag("-r","--rm", description: "Remove bottles that are not in the Brewfile.")
+    var removeNotPresent: Bool
+    
     func execute() throws {
         let runner = try ZeroRunner(
             configDirectory: self.configDirectory,
             workspace: self.workspace ?? [],
-            verbose: self.verbose
+            verbose: self.verbose,
+            removeNotPresent: self.removeNotPresent
         )
         try runner.workspaceDirectories.forEach(runner.bundle)
     }
@@ -25,7 +29,8 @@ extension ZeroRunner {
             Term.stdout <<< "No Brewfile found."
         } else {
             let verboseFlags: [String] = self.verbose ? ["--verbose"] : []
-            try Self.runTask("brew", arguments: ["bundle"] + verboseFlags, at: directory)
+            let removeNotPresentFlags: [String] = self.removeNotPresent ? ["--cleanup", "--zap"] : []
+            try Self.runTask("brew", arguments: ["bundle"] + verboseFlags + removeNotPresentFlags, at: directory)
         }
     }
 }

--- a/Sources/Zero/Commands/Setup.swift
+++ b/Sources/Zero/Commands/Setup.swift
@@ -10,12 +10,16 @@ final class SetupCommand: Command {
 
     @Flag("-a", "--all", description: "Update all casks, including those with auto-update enabled.")
     var updateAll: Bool
+    
+    @Flag("-r","--rm", description: "Remove bottles that are not in the Brewfile.")
+    var removeNotPresent: Bool
 
     func execute() throws {
         let runner = try ZeroRunner(
             configDirectory: self.configDirectory,
             workspace: self.workspace ?? [],
-            verbose: self.verbose
+            verbose: self.verbose,
+            removeNotPresent: self.removeNotPresent
         )
         try ZeroRunner.update(verbose: self.verbose, updateAll: self.updateAll)
         try runner.workspaceDirectories.forEach(runner.setup)

--- a/Sources/Zero/Runner.swift
+++ b/Sources/Zero/Runner.swift
@@ -33,8 +33,9 @@ struct ZeroRunner {
     let configDirectory: Path
     let workspace: Workspace
     let verbose: Bool
+    let removeNotPresent: Bool
 
-    init(configDirectory: Path? = nil, workspace: Workspace, verbose: Bool) throws {
+    init(configDirectory: Path? = nil, workspace: Workspace, verbose: Bool, removeNotPresent: Bool = false) throws {
         let fallbackDirectories: [Path] = [
             Path.XDG.configHome.join("zero").join("dotfiles"),
             Path.home.join(".dotfiles"),
@@ -43,6 +44,7 @@ struct ZeroRunner {
             fallbackDirectories.last!
         self.verbose = verbose
         self.workspace = workspace
+        self.removeNotPresent = removeNotPresent
         try validate()
     }
 


### PR DESCRIPTION
This is the addition of the remove flag mentioned inside the Pull Request #20 

I have added to the `setup` and `bundle` command the option `-r` or `--rm` that adds to the brew bundle command the `--cleanup` and `--zap` option.

The option will be applied to each workspaces since it's passed to the `ZeroRunner` with a default value to `false`.

However, I still see an issue that can cause problems with workspaces : the --zap and --cleanup options are passed to each brew bundle commands, for each workspaces. When launching the first brew bundle command (on the shared workspace), it will remove all bottles and casks from other workspaces.

I see a possible solution but it will require a breaking change in the way we process Brewfiles : instead of launching the brew command inside a directory, we can collect the content of the Brewfiles for each workspace, append it to a single big Brewfile and bundle this. What do you think @msanders ?